### PR TITLE
Add Cursor rules for C# conventions

### DIFF
--- a/.cursor/rules/csharp-conventions.mdc
+++ b/.cursor/rules/csharp-conventions.mdc
@@ -1,0 +1,35 @@
+---
+description: C# conventions for image-generation-server
+globs: **/*.cs
+alwaysApply: true
+---
+
+# C# Conventions
+
+## Local variables
+
+Use `var` when the type is obvious from the right-hand side.
+
+```csharp
+// ✅ preferred
+var audioBytes = await localAiImageService.GenerateBase64ImageAsync(prompt);
+
+// ❌ avoid when type is clear
+string audioBytes = await localAiImageService.GenerateBase64ImageAsync(prompt);
+```
+
+## Logging
+
+Use Serilog (`Log.Information`, `Log.Error`) — not `Console.WriteLine` in production code paths.
+
+## Configuration
+
+Inject options via `IOptions<T>` from `appsettings.json` sections. Env overrides use `__` (e.g. `ReplicateAiServiceOptions__Token`).
+
+## Async
+
+Prefer `async`/`await` over `.Result` or `.Wait()` on HTTP calls.
+
+## Scope
+
+Keep changes minimal — match existing patterns in `Services/` and `Controllers/`. Do not refactor unrelated code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ Generate (requires API key): `POST /image/generate/{phrase}` with header `X-API-
 - Change prompt model without eval and updating `IMAGE_PROMPT_MODEL_DECISION.md`
 - Include Claude attribution in commit messages
 
+## Cursor rules
+
+Committed agent hints: [`.cursor/rules/`](./.cursor/rules/) (C# conventions). Workspace-level `esl-all/.cursor/rules/` is local-only — not source of truth for cloud agents.
+
 ## Deep context
 
 See [CLAUDE.md](./CLAUDE.md) for pipeline architecture, services, config, and verify workflow.


### PR DESCRIPTION
Adds .cursor/rules/csharp-conventions.mdc and links from AGENTS.md.